### PR TITLE
add point-free example to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ const myView = () =>
     - [Builder Arguments](#builder-arguments)
     - [Dynamic Selectors](#dynamic-selectors)
   - [Argument Transformation](#argument-transformation)
+  - [Point-free](#point-free)
 - [Working with older versions](#working-with-older-versions)
 - [Contributions](#contributions)
 - [License](#license)
@@ -300,6 +301,34 @@ Please take into account that **all transformations are reduced on every argumen
 
 If you rather all your arguments to just be interpreted as they are, you can disable this feature by setting the `NJSXConfig.argumentTransformations` to an empty array.
 
+## Point-free style
+
+Think point-free composition in your render function is a `pipe` dream? Think again, you can use `njsx` to compose components in a point-free style to help with the readability of deeply tested react components:
+
+```jsx
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        <BrowserRouter>
+          <Route path="/" component={App} />
+        </BrowserRouter>
+      </PersistGate>
+    </Provider>
+```
+
+becomes:
+
+```js
+import { compose } from 'rambda'
+
+    compose(
+      PersistGate({ store }),
+      BrowserRouter({ loading: null, persistor }),
+      BrowserRouter,
+      Route
+    )({ path: '/', component: App })()
+```
+
+Please note that `compose` and `pipe` functions vary in implementation and not all will work with `njsx`, for example, `lodash/fp` seems to have issues at the moment, while `rambda` is working without issue.
 
 ## Working with older versions
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Think point-free composition in your render function is a `pipe` dream? Think ag
 </Provider>
 ```
 
-becomes:
+Becomes:
 
 ```js
 import { compose } from 'rambda'

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Becomes:
 import { compose } from 'rambda'
 
 compose(
-  Provider({ store })
+  Provider({ store }),
   PersistGate({ loading: null, persistor }),
   BrowserRouter,
   Route

--- a/README.md
+++ b/README.md
@@ -306,13 +306,13 @@ If you rather all your arguments to just be interpreted as they are, you can dis
 Think point-free composition in your render function is a `pipe` dream? Think again, you can use `njsx` to compose components in a point-free style to help with the readability of deeply tested react components:
 
 ```jsx
-    <Provider store={store}>
-      <PersistGate loading={null} persistor={persistor}>
-        <BrowserRouter>
-          <Route path="/" component={App} />
-        </BrowserRouter>
-      </PersistGate>
-    </Provider>
+<Provider store={store}>
+  <PersistGate loading={null} persistor={persistor}>
+    <BrowserRouter>
+      <Route path="/" component={App} />
+    </BrowserRouter>
+  </PersistGate>
+</Provider>
 ```
 
 becomes:
@@ -320,12 +320,12 @@ becomes:
 ```js
 import { compose } from 'rambda'
 
-    compose(
-      PersistGate({ store }),
-      BrowserRouter({ loading: null, persistor }),
-      BrowserRouter,
-      Route
-    )({ path: '/', component: App })()
+compose(
+  PersistGate({ store }),
+  BrowserRouter({ loading: null, persistor }),
+  BrowserRouter,
+  Route
+)({ path: '/', component: App })()
 ```
 
 Please note that `compose` and `pipe` functions vary in implementation and not all will work with `njsx`, for example, `lodash/fp` seems to have issues at the moment, while `rambda` is working without issue.

--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ Becomes:
 import { compose } from 'rambda'
 
 compose(
-  PersistGate({ store }),
-  BrowserRouter({ loading: null, persistor }),
+  Provider({ store })
+  PersistGate({ loading: null, persistor }),
   BrowserRouter,
   Route
 )({ path: '/', component: App })()

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Please take into account that **all transformations are reduced on every argumen
 
 If you rather all your arguments to just be interpreted as they are, you can disable this feature by setting the `NJSXConfig.argumentTransformations` to an empty array.
 
-## Point-free style
+## Point-free
 
 Think point-free composition in your render function is a `pipe` dream? Think again, you can use `njsx` to compose components in a point-free style to help with the readability of deeply tested react components:
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ If you rather all your arguments to just be interpreted as they are, you can dis
 
 ## Point-free
 
-Think point-free composition in your render function is a `pipe` dream? Think again, you can use `njsx` to compose components in a point-free style to help with the readability of deeply tested react components:
+Think point-free composition in your render function is a `pipe` dream? Think again, you can use `njsx` to compose components in a point-free style to help with the readability of deeply nested react components:
 
 ```jsx
 <Provider store={store}>


### PR DESCRIPTION
Thanks for the wonderful library. I was looking for a solution to the `jsx` problem for a while and was using a dinky converter function `const converter = el => (props, ...children) => h(el, props, ...children)` until I finally stumbled on `njsx`. I really like the solutions you have provided. I wanted to contribute a little and so I added some lines in the docs regarding point-free composition. I found that `lodash/fp`.`compose` blows up but that `rambda.compose` works great.

Let me know if there's anything else I can do.

Thanks!